### PR TITLE
fix: Added info config to ToastOptions

### DIFF
--- a/projects/ngneat/hot-toast/src/lib/hot-toast.model.ts
+++ b/projects/ngneat/hot-toast/src/lib/hot-toast.model.ts
@@ -25,6 +25,7 @@ export class ToastConfig implements DefaultToastOptions {
   attributes: Record<string, string> = {};
 
   // key in ToastType
+  info: ToastOptions<unknown> & { content?: Content } = { content: '' };
   success: ToastOptions<unknown> & { content?: Content } = { content: '' };
   error: ToastOptions<unknown> & { content?: Content } = { content: '' };
   loading: ToastOptions<unknown> & { content?: Content } = { content: '' };

--- a/projects/ngneat/hot-toast/src/lib/hot-toast.service.ts
+++ b/projects/ngneat/hot-toast/src/lib/hot-toast.service.ts
@@ -157,9 +157,9 @@ export class HotToastService implements HotToastServiceMethods {
    * @since 3.3.0
    */
   info<DataType>(message?: Content, options?: ToastOptions<DataType>): CreateHotToastRef<DataType | unknown> {
-    const toast = this.createToast<DataType>(message || this._defaultConfig.warning.content, 'info', {
+    const toast = this.createToast<DataType>(message || this._defaultConfig.info.content, 'info', {
       ...this._defaultConfig,
-      ...this._defaultConfig?.warning,
+      ...this._defaultConfig?.info,
       ...options,
     });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Missing config key and incorrect styles applied for Info toast messages.

Issue Number: [120](https://github.com/ngneat/hot-toast/issues/120)

## What is the new behavior?

Info toast styles will not be overridden with warning styles and have a config key.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
