### PR TITLE
feat: Add button to trigger callback action

### DIFF
--- a/cypress/e2e/toast_callback.cy.ts
+++ b/cypress/e2e/toast_callback.cy.ts
@@ -1,0 +1,24 @@
+/// <reference types="cypress" />
+import { HOT_TOAST_DEFAULT_TIMEOUTS } from '../../projects/ngneat/hot-toast/src/lib/constants';
+
+describe('Test toasts with callback - component', () => {
+  it('should show and hide component toast', () => {
+    cy.window().then((win) => {
+      cy.stub(win.console, 'log').as('consoleLog');
+    });
+
+    cy.get('#callback').click();
+    cy.get('hot-toast').as('componentToast');
+    cy.get('@componentToast').should('contain', 'Something went wrong');
+    cy.get('@componentToast').find('.hot-toast-action-btn').as('actionButton').should('exist');
+
+    cy.get('@actionButton').should('contain', 'Retry');
+    cy.get('@actionButton').should('have.attr', 'aria-label', 'Retry the request');
+    cy.get('@actionButton').click();
+
+    cy.get('@consoleLog').should('be.calledWith', 'callback clicked');
+
+    cy.wait(HOT_TOAST_DEFAULT_TIMEOUTS.blank);
+    cy.get('hot-toast').should('not.exist');
+  });
+});

--- a/projects/ngneat/hot-toast/src/lib/components/hot-toast/hot-toast.component.html
+++ b/projects/ngneat/hot-toast/src/lib/components/hot-toast/hot-toast.component.html
@@ -34,7 +34,16 @@
         <ng-container *dynamicView="toast.message; context: context; injector: toastComponentInjector"></ng-container>
       </div>
     </div>
-
+    <button
+      *ngIf="toast.action"
+      (click)="executeAction()"
+      type="button"
+      class="hot-toast-action-btn"
+      [attr.aria-label]="toast.action.ariaLabel ?? toast.action.label"
+      [ngStyle]="toast.actionStyle"
+    >
+      {{ toast.action.label }}
+    </button>
     <button
       *ngIf="toast.dismissible"
       (click)="close()"

--- a/projects/ngneat/hot-toast/src/lib/components/hot-toast/hot-toast.component.ts
+++ b/projects/ngneat/hot-toast/src/lib/components/hot-toast/hot-toast.component.ts
@@ -164,6 +164,11 @@ export class HotToastComponent implements OnInit, AfterViewInit, OnDestroy, OnCh
     animate(nativeElement, exitAnimation);
   }
 
+  executeAction() {
+    this.toast.action.callback();
+    this.close();
+  }
+
   ngOnDestroy() {
     this.close();
     while (this.unlisteners.length) {

--- a/projects/ngneat/hot-toast/src/lib/hot-toast.model.ts
+++ b/projects/ngneat/hot-toast/src/lib/hot-toast.model.ts
@@ -15,6 +15,7 @@ export class ToastConfig implements DefaultToastOptions {
   position: ToastPosition = 'top-center';
   className: string;
   closeStyle: any;
+  actionStyle: any;
   dismissible: boolean;
   autoClose = true;
   duration: number;
@@ -39,6 +40,12 @@ export type ToastPosition = 'top-left' | 'top-center' | 'top-right' | 'bottom-le
 export type IconTheme = {
   primary: string;
   secondary?: string;
+};
+
+export type Action = {
+  label: string;
+  callback: () => void;
+  ariaLabel?: string;
 };
 
 export type ToastTheme = 'toast' | 'snackbar';
@@ -138,6 +145,9 @@ export interface Toast<DataType> {
   /**Extra styles to apply for close button */
   closeStyle?: any;
 
+  /**Extra styles to apply for action button */
+  actionStyle?: any;
+
   createdAt: number;
   visible: boolean;
   height?: number;
@@ -174,6 +184,14 @@ export interface Toast<DataType> {
    * @memberof Toast
    */
   data?: DataType;
+
+  /**
+   * Allows you to pass a callback function to the toast
+   *
+   * @type {DataType}
+   * @memberof Toast
+   */
+  action?: Action;
 }
 
 export type ToastOptions<DataType> = Partial<
@@ -196,6 +214,8 @@ export type ToastOptions<DataType> = Partial<
     | 'injector'
     | 'data'
     | 'attributes'
+    | 'action'
+    | 'actionStyle'
   >
 >;
 
@@ -230,7 +250,16 @@ export interface HotToastServiceMethods {
 export type UpdateToastOptions<DataType> = Partial<
   Pick<
     Toast<DataType>,
-    'icon' | 'duration' | 'dismissible' | 'className' | 'style' | 'iconTheme' | 'type' | 'theme' | 'closeStyle'
+    | 'icon'
+    | 'duration'
+    | 'dismissible'
+    | 'className'
+    | 'style'
+    | 'iconTheme'
+    | 'type'
+    | 'theme'
+    | 'closeStyle'
+    | 'actionStyle'
   >
 >;
 

--- a/projects/ngneat/hot-toast/src/lib/hot-toast.service.ts
+++ b/projects/ngneat/hot-toast/src/lib/hot-toast.service.ts
@@ -302,6 +302,7 @@ export class HotToastService implements HotToastServiceMethods {
         type,
         visible: true,
         observableMessages: observableMessages ?? undefined,
+        action: options?.action,
         ...options,
       };
 

--- a/projects/ngneat/hot-toast/src/styles/components/_hot-toast.scss
+++ b/projects/ngneat/hot-toast/src/styles/components/_hot-toast.scss
@@ -142,3 +142,21 @@
     transform: translate3d(0, -130px, -1px) scale(0.5);
   }
 }
+
+.hot-toast-action-btn {
+  background-color: var(--hot-toast-action-btn-bg, transparent);
+  border: var(--hot-toast-action-btn-border, none);
+  border-radius: var(--hot-toast-action-btn-border-radius, 4px);
+  color: var(--hot-toast-action-btn-color, #007bff);
+  cursor: var(--hot-toast-action-btn-cursor, pointer);
+  margin-left: var(--hot-toast-action-btn-margin-left, 5px);
+  padding: var(--hot-toast-action-btn-padding, 5px 10px);
+
+  &:hover {
+    background-color: var(--hot-toast-action-btn-hover-bg, #f8f9fa);
+  }
+
+  &:active {
+    background-color: var(--hot-toast-action-btn-active-bg, #e2e6ea);
+  }
+}

--- a/src/app/sections/example/example.component.ts
+++ b/src/app/sections/example/example.component.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import { Component, Inject, Injector, OnInit, Optional, ViewChild } from '@angular/core';
 import { HotToastClose, HotToastRef, HotToastService } from '@ngneat/hot-toast';
-import { from, of } from 'rxjs';
+import { Subject, from, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 interface Example {
@@ -26,6 +26,7 @@ export class ExampleComponent implements OnInit {
   @ViewChild('templateContext') ngTemplateContext;
 
   examples: Example[] = [];
+  action$ = new Subject<void>();
 
   closedEventData: HotToastClose = undefined;
 
@@ -599,8 +600,64 @@ export class ExampleComponent implements OnInit {
           });
         },
       },
+      {
+        id: 'callback',
+        title: 'Callback',
+        subtitle:
+          'You can open a toast with a button to execute a callback function such as to undo an action or retry a request. Accepts an optional <b><code>ariaLabel</b></code> for accessibility. The <b><code>ariaLabel</code></b> will default to the <b><code>label</b></code> if none is provided. </br> Use <b><code>autoClose</b></code> to render the exit animation. Use <b><code>actionStyle</b></code> to style the button.',
+        emoji: '↩',
+        activeSnippet: 'typescript',
+        snippet: {
+          typescript: `
+  action$ = new Subject<void>();
+
+  ngOnInit(): void {
+    this.action$.subscribe(() => {
+      console.log('callback clicked');
+    });
+  }
+  ...
+  this.toast.error('Something went wrong', {
+    autoClose: false,
+    action: {
+      label: 'Retry',
+      ariaLabel: 'Retry the request',
+      callback: () => {
+        this.action$.next();
+      },
+    },
+    actionStyle: {
+      border: '1px solid #713200',
+      fontFamily: 'serif',
+      color: '#713200',
+    },
+  });
+  `,
+        },
+        action: () => {
+          this.toast.error('Something went wrong', {
+            autoClose: false,
+            action: {
+              label: 'Retry',
+              ariaLabel: 'Retry the request',
+              callback: () => {
+                this.action$.next();
+              },
+            },
+            actionStyle: {
+              border: '1px solid #713200',
+              fontFamily: 'serif',
+              color: '#713200',
+            },
+          });
+        },
+      },
     ];
     Array.prototype.push.apply(this.examples, examples);
+
+    this.action$.subscribe(() => {
+      console.log('callback clicked');
+    });
   }
 
   click(e: Example) {


### PR DESCRIPTION
Adds a new feature enabling an optional action button to be added to toast messages. This action button can be customized with a label and a callback function, providing additional user interaction possibilities. It also adds an optional style input to style the action button.

✅ Closes: 8

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Updated the Toast interface to include an optional action property. This property is an object consisting of a label (the text to be displayed on the button) and a callback (the function to be executed when the action button is clicked).

Modified the createToast method in our HotToastService to accept and handle the new action property.

Added a new `executeAction` method in the HotToastComponent that triggers the callback function and closes the toast.

Updated the HotToastComponent template to conditionally render the action button based on the presence of the action property.

Introduced new custom CSS properties for easy theming of the action button.

Added test coverage to ensure that the action button functions as expected, including a check that the callback function is executed when the action button is clicked.

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

There is no option to easily execute callback functions from a toast.  

Issue Number: 8

## What is the new behavior?

There is an optional action property that can be configured to trigger a callback when the user clicks the action button in the toast. 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

This new feature enhances the interactivity of our toast notifications, allowing us to provide users with actionable options directly within the notifications themselves.
